### PR TITLE
Change to using modulo function

### DIFF
--- a/src/main/scala/Config/Config.scala
+++ b/src/main/scala/Config/Config.scala
@@ -309,7 +309,7 @@ case class Config(
     val alphaB = Wire(UInt(SYMB_WIDTH.W))
     alphaA := symbToAlpha(symbA)
     alphaB := symbToAlpha(symbB)
-    alphaSum := (alphaA + alphaB) % FIELD_CHAR.U
+    alphaSum := RsUtil.modulo(alphaA +& alphaB, FIELD_CHAR)
     when((symbA === 0.U) | (symbB === 0.U)){
       mult := 0.U
     }.otherwise{
@@ -322,7 +322,7 @@ case class Config(
     val alphaDivd = symbToAlpha(dividend)
     val alphaDvdr = symbToAlpha(divider)
     // TODO: use +& instead of implicit cast.
-    val alphaDiff = (FIELD_CHAR.U.asTypeOf(UInt((SYMB_WIDTH+1).W))+alphaDivd-alphaDvdr)%FIELD_CHAR.U
+    val alphaDiff = RsUtil.modulo(FIELD_CHAR.U.asTypeOf(UInt((SYMB_WIDTH+1).W))+&alphaDivd-alphaDvdr,FIELD_CHAR)
     val gfDivVal = Wire(UInt(SYMB_WIDTH.W))
     when(dividend === 0.U) {
       gfDivVal := 0.U
@@ -341,7 +341,7 @@ case class Config(
 
   def gfPow(x : UInt, degree : UInt) : UInt = {
     val alpha = symbToAlpha(x)
-    val alphaPow = (alpha * degree) % FIELD_CHAR.U
+    val alphaPow = RsUtil.modulo(alpha * degree, FIELD_CHAR)
     val xDegree = alphaToSymb(alphaPow)
     xDegree
   }

--- a/src/main/scala/RsUtil.scala
+++ b/src/main/scala/RsUtil.scala
@@ -1,0 +1,59 @@
+package Rs
+
+import chisel3._
+import chisel3.util.{MuxLookup, log2Ceil}
+
+object RsUtil {
+  def isPowerOfTwo(n: Int): (Boolean, Int) = {
+    if (n <= 0) (false, -1)
+    else if ((n & (n - 1)) == 0) (true, Integer.numberOfTrailingZeros(n))
+    else (false, -1)
+  }
+
+  def modulo(a : UInt, b : Int, mtype : String = "barrett") : UInt = {
+    mtype match {
+      case "barrett" =>
+        val bitWidth = if ((a.getWidth & 1) == 1) a.getWidth / 2 + 1 else a.getWidth / 2
+        val m = b.U(bitWidth.max(log2Ceil(b)).W)
+        val k = 2 * bitWidth
+        val mu = ((BigInt(1) << k) / b).U((k + 1).W) // Precomputed value of mu = floor(2^(2*bitWidth) / m)
+
+        // Compute q = floor(x / m) using Barrett reduction approximation
+        val q = (a * mu) >> k
+
+        // Compute r = x - q * m
+        val r = a - (q * m)
+
+        // If r >= m, subtract m
+        Mux(r >= m, r - m, r)
+      case "unrolled" =>
+        val constMap = for  {
+          i <- 0 until (1 << a.getWidth)
+          if (i >= b)
+        } yield i.U -> (i % b).U
+        MuxLookup(a, a)(constMap)
+      case _ =>
+        a % b.U
+    }
+  }
+
+  def const_mul(x: UInt, mul: Int): UInt = {
+    require(mul >= 0)
+    if (mul > 0) {
+      var shift: Int = 0
+      var m: Int = mul
+      val width = x.getWidth + log2Ceil(mul)
+      val mstage = Wire(Vec(log2Ceil(mul + 1), UInt(width.W)))
+      while (m > 0) {
+        if ((m & 1) == 1) {
+          mstage(shift) := x << shift
+        } else {
+          mstage(shift) := 0.U
+        }
+        shift += 1
+        m = m >> 1
+      }
+      mstage.reduce(_ + _)
+    } else 0.U
+  }
+}

--- a/src/main/scala/RsUtil.scala
+++ b/src/main/scala/RsUtil.scala
@@ -10,7 +10,7 @@ object RsUtil {
     else (false, -1)
   }
 
-  def modulo(a : UInt, b : Int, mtype : String = "barrett") : UInt = {
+  def modulo(a : UInt, b : Int, mtype : String = "default") : UInt = {
     mtype match {
       case "barrett" =>
         val bitWidth = if ((a.getWidth & 1) == 1) a.getWidth / 2 + 1 else a.getWidth / 2


### PR DESCRIPTION
Add RsUtil object with utility functions, change to using RsUtil.modulo instead of inline modulo operator.

This allows multiple implementations of the modulo function and future optimization, even though Barrett reduction proved to have worse area and timing than basic modulo operator.